### PR TITLE
Fixed some bugs about mangling members of classes

### DIFF
--- a/roro_ioc/ast_injection.py
+++ b/roro_ioc/ast_injection.py
@@ -46,14 +46,22 @@ class _ManglePrivateMembers(NodeTransformer):
         self.generic_visit(node)
 
         attribute_name = node.attr
-        if attribute_name.startswith('__') and (not attribute_name.endswith('__')) and self.class_name:
-            mangled_name = '_{}{}'.format(self.class_name, attribute_name)
+        if self._should_mangle(attribute_name):
+            mangled_name = self._get_mangled_name(attribute_name)
             return copy_location(
                 Attribute(value=node.value, attr=mangled_name, ctx=node.ctx),
                 node
             )
         else:
             return node
+
+    def _should_mangle(self, attribute_name):
+        return attribute_name.startswith('__') and (not attribute_name.endswith('__')) and self.class_name
+
+    def _get_mangled_name(self, attribute_name):
+        mangled_class_name = '_{}'.format(self.class_name.lstrip('_'))
+        mangled_name = '{}{}'.format(mangled_class_name, attribute_name)
+        return mangled_name
 
 
 class _InjectParameters(NodeTransformer):

--- a/tests/test_structured_injection.py
+++ b/tests/test_structured_injection.py
@@ -135,5 +135,29 @@ class TestStructuredInjection(TestCase):
         with self._arm():
             self.assertEqual(2, MockWithMangledNames().foo())
 
+    def test_inject_method_to_underscored_class_name(self):
+        @inject_methods(TEST_PARAMETERS_IOC_CONTAINER)
+        class _MockWithMangledNames(object):
+            def foo(self, a=INJECTED):
+                return self.__foo() + a
+
+            def __foo(self):
+                return 0
+
+        with self._arm():
+            self.assertEqual(2, _MockWithMangledNames().foo())
+
+    def test_inject_method_to_mangled_class_name(self):
+        @inject_methods(TEST_PARAMETERS_IOC_CONTAINER)
+        class __MockWithMangledNames(object):
+            def foo(self, a=INJECTED):
+                return self.__foo() + a
+
+            def __foo(self):
+                return 0
+
+        with self._arm():
+            self.assertEqual(2, __MockWithMangledNames().foo())
+
     def _arm(self):
         return TEST_PARAMETERS_IOC_CONTAINER.arm(Parameters(2, 3))


### PR DESCRIPTION
Had trouble with renaming of class members (ast attributes) of classes that are prefixed with underscore or are mangled
@uri-yanover 