### PR TITLE
instance_ioc_container.py: obtain all resources from payload before integrating them

### DIFF
--- a/roro_ioc/instance_ioc_container.py
+++ b/roro_ioc/instance_ioc_container.py
@@ -83,14 +83,19 @@ class InstanceIOCContainer(IOCContainer):
 def _integrate_resources(ioc_container, fast_retrieval_context, payload):
     if not hasattr(fast_retrieval_context, 'resources'):
         fast_retrieval_context.resources = []
-    for resource_name in ioc_container.provides:
-        handle = get_fast_retrieval_resource_handle(ioc_container, resource_name)
-        current_length = len(fast_retrieval_context.resources)
-        if handle >= current_length:
-            fast_retrieval_context.resources.extend([fast_retrieval_context] * (1 + handle - current_length))
-        assert fast_retrieval_context.resources[handle] is fast_retrieval_context
-        fast_retrieval_context.resources[handle] = getattr(payload, resource_name)
 
+    handles_to_resources = {
+        get_fast_retrieval_resource_handle(ioc_container, resource_name): getattr(payload, resource_name)
+        for resource_name in ioc_container.provides}
+
+    max_handle = max(handles_to_resources)
+    current_length = len(fast_retrieval_context.resources)
+    if max_handle >= current_length:
+        fast_retrieval_context.resources.extend([fast_retrieval_context] * (1 + max_handle - current_length))
+
+    for handle, resource in handles_to_resources.iteritems():
+        assert fast_retrieval_context.resources[handle] is fast_retrieval_context
+        fast_retrieval_context.resources[handle] = resource
 
 # fast_retrieval_context is used as a placeholder for resources that are not currently provided
 def _cleanup_resources(ioc_container, fast_retrieval_context):


### PR DESCRIPTION
This addresses the issue when attempting to obtain a resource from the payload throws an exception. In the original implementation, the integration process is not atomic, and so any exception thrown mid-way would cause all previously integrated resources to stay integrated, but without the arm operation considered successful; this in turn will not clean them up during un-arm, and will fail subsequent attempt at arming the same container because of the assertion that checks that each resource being integrated has not already been integrated. 

The new implementation obtains all the resources from the payload first, so that any exceptions are raised at that point, and before any state has been changed. Only if all the resources have been obtained successfully we continue and integrate them all into the context. As a bonus, the check that extends the context to accommodate out-of-bounds handle numbers can now happen once per arming rather than once per provided resource.

This addresses issue #16.